### PR TITLE
Removed 'might' from wrong words

### DIFF
--- a/Hedging.yml
+++ b/Hedging.yml
@@ -7,7 +7,6 @@ tokens:
   - arguably
   - in general
   - likely
-  - might
   - more or less
   - possibly
   - presumably


### PR DESCRIPTION
fixes https://github.com/openSUSE/suse-vscode-doc/issues/26