### PR TITLE
changed Link.yml scope to resolve terminal error

### DIFF
--- a/Link.yml
+++ b/Link.yml
@@ -1,7 +1,7 @@
 message: "Don't use '%s' as the content of a link."
 extends: existence
 ignorecase: true
-scope: link
+scope: raw
 level: error
 tokens:
   - here


### PR DESCRIPTION
Changed scope `link` to `raw` in `Link.yml` to resolve this terminal error when using the `vale` command:

```
E201 Invalid value [/home/gabriel/styles/suse-vale-styleguide/Link.yml:4:1]:

   3  ignorecase: true
   4* scope: link
   5  level: error
   6  tokens:

scope 'link' is no longer supported; use 'raw' instead. 
```
This error occurred after following the [Linux installation guide](https://github.com/openSUSE/suse-vale-styleguide#installation-on-linux) to get the SUSE style guide and Vale version 2.28.1 on lubuntu. 