### PR TITLE
Increasing word limit in SentenceLength.yml to 25

### DIFF
--- a/common/SentenceLength.yml
+++ b/common/SentenceLength.yml
@@ -1,5 +1,5 @@
 extends: occurrence
-message: "Each sentence should be limited to 20 words or fewer."
+message: "Each sentence should be limited to 25 words or fewer."
 level: suggestion
 scope: sentence
 max: 25

--- a/common/SentenceLength.yml
+++ b/common/SentenceLength.yml
@@ -2,5 +2,5 @@ extends: occurrence
 message: "Each sentence should be limited to 20 words or fewer."
 level: suggestion
 scope: sentence
-max: 20
+max: 25
 token: \b(\w+)\b

--- a/tests/SentenceLength-bad.txt
+++ b/tests/SentenceLength-bad.txt
@@ -1,1 +1,3 @@
-This particular one has more than twenty words because I need an example sentence that does exceed the maximum number of words.
+This particular one has more than twenty-five words because we need an example sentence that does exceed the maximum number of words, showcasing the rule in all its magnificence.
+Of course, some can argue that the tests here could be written with a more professional tone, to inspire greater confidence in the writer's commitment to corporate values.
+We welcome such contributors with open arms, such that they can be the change they want to see in this wonderful yet tiring world of ours.

--- a/tests/SentenceLength-good.txt
+++ b/tests/SentenceLength-good.txt
@@ -1,3 +1,3 @@
-This sentence has less than twenty-five words for sure.
+This sentence has less than twenty-five words, for sure.
 So does this one.
-One could say, without necessarily being charitable or duplicitous, that even this oddly constructed example has less than 25 words.
+One could say, without necessarily being charitable nor a hint of duplicity, that even this oddly constructed collection of words only has 25 of them.

--- a/tests/SentenceLength-good.txt
+++ b/tests/SentenceLength-good.txt
@@ -1,3 +1,3 @@
-This sentence has less than twenty five words for sure.
+This sentence has less than twenty-five words for sure.
 So does this one.
-One could note, without necessarily being charitable or duplicitous, that even this oddly construced example has less than 25 words.
+One could say, without necessarily being charitable or duplicitous, that even this oddly constructed example has less than 25 words.

--- a/tests/SentenceLength-good.txt
+++ b/tests/SentenceLength-good.txt
@@ -1,1 +1,3 @@
-This sentence has less than twenty words for sure.
+This sentence has less than twenty five words for sure.
+So does this one.
+One could note, without necessarily being charitable or duplicitous, that even this oddly construced example has less than 25 words.


### PR DESCRIPTION
SUSE has now decided to change the word limit to 25, you can view the comments and decision in SUSE/doc-styleguide/issues/299. I've modified the rules and the relevant tests accordingly.

I haven't forgotten about the idea of adding a readability rule as well, but I'd suggest we add that one and the required tests in a separate pull request.