### PR TITLE
Links

### DIFF
--- a/common/AcronymApostrophe.yml
+++ b/common/AcronymApostrophe.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: "The acronym [%s] should not be in possesive form or used with an apostrophe in plural form."
-link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-acronym
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-acronym
 level: error
 ignorecase: false
 tokens:

--- a/common/AcronymApostrophe.yml
+++ b/common/AcronymApostrophe.yml
@@ -1,5 +1,6 @@
 extends: existence
 message: "The acronym [%s] should not be in possesive form or used with an apostrophe in plural form."
+link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-acronym
 level: error
 ignorecase: false
 tokens:

--- a/common/AmericanSpelling.yml
+++ b/common/AmericanSpelling.yml
@@ -1,5 +1,6 @@
 extends: existence
 message: "In general, use American spelling instead of '%s'."
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html
 ignorecase: true
 level: warning
 tokens:

--- a/common/AmericanSpelling.yml
+++ b/common/AmericanSpelling.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: "In general, use American spelling instead of '%s'."
-link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#
 ignorecase: true
 level: warning
 tokens:

--- a/common/Contractions.yml
+++ b/common/Contractions.yml
@@ -1,5 +1,6 @@
 extends: substitution
 message: "Use '%s' instead of '%s'."
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-contraction
 level: error
 ignorecase: true
 action:

--- a/common/CorporateSpeak.yml
+++ b/common/CorporateSpeak.yml
@@ -1,5 +1,6 @@
 extends: existence
 message: "'%s' is corporate speak."
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-webwriting.html#sec-writing-global
 ignorecase: true
 level: error
 tokens:

--- a/common/DoubleDash.yml
+++ b/common/DoubleDash.yml
@@ -1,5 +1,6 @@
 extends: substitution
 message: "Replace double dash with an entity."
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-dash
 level: warning
 action:
   name: replace

--- a/common/Editorializing.yml
+++ b/common/Editorializing.yml
@@ -1,5 +1,6 @@
 extends: existence
 message: "Consider removing '%s'"
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-webwriting.html#sec-writing-global
 ignorecase: true
 level: warning
 tokens:

--- a/common/EmDash.yml
+++ b/common/EmDash.yml
@@ -1,5 +1,6 @@
 extends: existence
 message: "Do not put a space before or after a dash."
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-dash
 scope: raw
 nonword: true
 level: error

--- a/common/Exclamation.yml
+++ b/common/Exclamation.yml
@@ -1,5 +1,6 @@
 extends: existence
 message: "Avoid using exclamation points in text."
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-end-sentence
 nonword: true
 level: error
 tokens:

--- a/common/Hardware.yml
+++ b/common/Hardware.yml
@@ -1,5 +1,6 @@
 extends: substitution
 message: Consider using '%s' instead of '%s'
+link: https://documentation.suse.com/style/current/html/docu_styleguide/app-terminology.html#sec-terminology
 ignorecase: false
 level: error
 swap:

--- a/common/Hedging.yml
+++ b/common/Hedging.yml
@@ -1,5 +1,6 @@
 extends: existence
 message: "Consider removing '%s'"
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-webwriting.html#sec-writing-global
 ignorecase: true
 level: warning
 tokens:

--- a/common/InclusiveLanguage.yml
+++ b/common/InclusiveLanguage.yml
@@ -1,4 +1,5 @@
 extends: existence
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-bias
 ignorecase: true
 level: warning
 message: "Consider using an inclusive term instead of '%s'"

--- a/common/Latin.yml
+++ b/common/Latin.yml
@@ -1,5 +1,6 @@
 extends: substitution
 message: "Use '%s' instead of '%s'."
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-latin
 ignorecase: true
 level: error
 nonword: true

--- a/common/LyHyphen.yml
+++ b/common/LyHyphen.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: "'%s' doesn't need a hyphen."
-link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-hyphens
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-hyphens
 level: error
 ignorecase: false
 nonword: true

--- a/common/LyHyphen.yml
+++ b/common/LyHyphen.yml
@@ -1,5 +1,6 @@
 extends: existence
 message: "'%s' doesn't need a hyphen."
+link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-hyphens
 level: error
 ignorecase: false
 nonword: true

--- a/common/Periods.yml
+++ b/common/Periods.yml
@@ -1,5 +1,6 @@
 extends: existence
 message: "Don't use periods with acronyms or initialisms such as '%s'."
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-acronym
 level: error
 nonword: true
 tokens:

--- a/common/Pronouns.yml
+++ b/common/Pronouns.yml
@@ -1,4 +1,5 @@
 extends: existence
+link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-bias
 ignorecase: true
 level: warning
 message: "Consider using a gender-neutral term instead of '%s'"

--- a/common/Pronouns.yml
+++ b/common/Pronouns.yml
@@ -1,5 +1,5 @@
 extends: existence
-link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-bias
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-bias
 ignorecase: true
 level: warning
 message: "Consider using a gender-neutral term instead of '%s'"

--- a/common/Quotes.yml
+++ b/common/Quotes.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: "Commas and periods go inside quotation marks."
-link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-quotation
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-quotation
 scope: text
 nonword: true
 level: error

--- a/common/Quotes.yml
+++ b/common/Quotes.yml
@@ -1,5 +1,6 @@
 extends: existence
 message: "Commas and periods go inside quotation marks."
+link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-quotation
 scope: text
 nonword: true
 level: error

--- a/common/QuotesRaw.yml
+++ b/common/QuotesRaw.yml
@@ -1,5 +1,6 @@
 extends: existence
 message: "Commas and periods go inside quotation marks."
+link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-quotation
 scope: raw
 level: error
 tokens:

--- a/common/QuotesRaw.yml
+++ b/common/QuotesRaw.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: "Commas and periods go inside quotation marks."
-link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-quotation
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-quotation
 scope: raw
 level: error
 tokens:

--- a/common/Semicolons.yml
+++ b/common/Semicolons.yml
@@ -1,5 +1,6 @@
 extends: existence
 message: "Only use semicolons in complicated lists with punctuation."
+link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-semicolon
 nonword: true
 scope: sentence
 level: suggestion

--- a/common/Semicolons.yml
+++ b/common/Semicolons.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: "Only use semicolons in complicated lists with punctuation."
-link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-semicolon
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-semicolon
 nonword: true
 scope: sentence
 level: suggestion

--- a/common/SentenceLength.yml
+++ b/common/SentenceLength.yml
@@ -1,5 +1,6 @@
 extends: occurrence
 message: "Each sentence should be limited to 25 words or fewer."
+link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-structure-sentence
 level: suggestion
 scope: sentence
 max: 25

--- a/common/SentenceLength.yml
+++ b/common/SentenceLength.yml
@@ -1,6 +1,6 @@
 extends: occurrence
 message: "Each sentence should be limited to 25 words or fewer."
-link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-structure-sentence
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-structure-sentence
 level: suggestion
 scope: sentence
 max: 25

--- a/common/SimpleSeries.yml
+++ b/common/SimpleSeries.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: "Simple series, consider removing the last comma in '%s'."
-link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-comma
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-comma
 scope: sentence
 level: warning
 raw:

--- a/common/SimpleSeries.yml
+++ b/common/SimpleSeries.yml
@@ -1,5 +1,6 @@
 extends: existence
 message: "Simple series, consider removing the last comma in '%s'."
+link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-comma
 scope: sentence
 level: warning
 raw:

--- a/common/Slash.yml
+++ b/common/Slash.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: 'Only use slashes with filenames, links and terms such as TCP/IP in "%s"'
-link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-slash
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-slash
 ignorecase: true
 level: suggestion
 tokens:

--- a/common/Slash.yml
+++ b/common/Slash.yml
@@ -1,5 +1,6 @@
 extends: existence
 message: 'Only use slashes with filenames, links and terms such as TCP/IP in "%s"'
+link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-slash
 ignorecase: true
 level: suggestion
 tokens:

--- a/common/SurroundingCommas.yml
+++ b/common/SurroundingCommas.yml
@@ -1,5 +1,6 @@
 extends: existence
 message: "Delimit the phrase with comma(s)."
+link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-comma
 level: error
 nonword: true
 tokens:

--- a/common/SurroundingCommas.yml
+++ b/common/SurroundingCommas.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: "Delimit the phrase with comma(s)."
-link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-comma
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-comma
 level: error
 nonword: true
 tokens:

--- a/common/Terms.yml
+++ b/common/Terms.yml
@@ -1,6 +1,6 @@
 extends: substitution
 message: Consider using '%s' instead of '%s'
-link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-terminology
+link: https://documentation.suse.com/style/current/html/docu_styleguide/app-terminology.html#sec-terminology
 ignorecase: false
 nonword: true
 level: error

--- a/common/Terms.yml
+++ b/common/Terms.yml
@@ -1,5 +1,6 @@
 extends: substitution
 message: Consider using '%s' instead of '%s'
+link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-terminology
 ignorecase: false
 nonword: true
 level: error

--- a/common/TermsIgnorecase.yml
+++ b/common/TermsIgnorecase.yml
@@ -1,6 +1,6 @@
 extends: substitution
 message: Use '%s' instead of '%s'
-link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-terminology
+link: https://documentation.suse.com/style/current/html/docu_styleguide/app-terminology.html#sec-terminology
 ignorecase: true
 level: error
 swap:

--- a/common/TermsIgnorecase.yml
+++ b/common/TermsIgnorecase.yml
@@ -1,5 +1,6 @@
 extends: substitution
 message: Use '%s' instead of '%s'
+link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-terminology
 ignorecase: true
 level: error
 swap:

--- a/common/Termweb.yml
+++ b/common/Termweb.yml
@@ -1,6 +1,6 @@
 extends: substitution
 message: "Consider using '%s' instead of '%s'."
-link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-terminology
+link: https://documentation.suse.com/style/current/html/docu_styleguide/app-terminology.html#sec-terminology
 level: warning
 ignorecase: false
 action:

--- a/common/Termweb.yml
+++ b/common/Termweb.yml
@@ -1,5 +1,6 @@
 extends: substitution
 message: "Consider using '%s' instead of '%s'."
+link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-terminology
 level: warning
 ignorecase: false
 action:

--- a/common/TermwebProducts3rdParty.yml
+++ b/common/TermwebProducts3rdParty.yml
@@ -1,6 +1,6 @@
 extends: substitution
 message: "Use an entity or '%s' instead of '%s'."
-link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-terminology
+link: https://documentation.suse.com/style/current/html/docu_styleguide/app-terminology.html#sec-terminology
 level: warning
 ignorecase: false
 action:

--- a/common/TermwebProducts3rdParty.yml
+++ b/common/TermwebProducts3rdParty.yml
@@ -1,5 +1,6 @@
 extends: substitution
 message: "Use an entity or '%s' instead of '%s'."
+link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-terminology
 level: warning
 ignorecase: false
 action:

--- a/common/TermwebProductsSUSE.yml
+++ b/common/TermwebProductsSUSE.yml
@@ -1,6 +1,6 @@
 extends: substitution
 message: "Use an entity or '%s' instead of '%s'."
-link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-terminology
+link: https://documentation.suse.com/style/current/html/docu_styleguide/app-terminology.html#sec-terminology
 level: warning
 ignorecase: false
 action:

--- a/common/TermwebProductsSUSE.yml
+++ b/common/TermwebProductsSUSE.yml
@@ -1,5 +1,6 @@
 extends: substitution
 message: "Use an entity or '%s' instead of '%s'."
+link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-terminology
 level: warning
 ignorecase: false
 action:

--- a/common/Usage.yml
+++ b/common/Usage.yml
@@ -1,6 +1,6 @@
 extends: substitution
 message: "Use '%s' instead of '%s'."
-link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-terminology
+link: https://documentation.suse.com/style/current/html/docu_styleguide/app-terminology.html#sec-terminology
 level: warning
 ignorecase: true
 action:

--- a/common/Usage.yml
+++ b/common/Usage.yml
@@ -1,5 +1,6 @@
 extends: substitution
 message: "Use '%s' instead of '%s'."
+link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-terminology
 level: warning
 ignorecase: true
 action:

--- a/common/Will.yml
+++ b/common/Will.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: "Avoid using future tense where possible"
-link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-tense
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-tense
 ignorecase: true
 level: warning
 tokens:

--- a/common/Will.yml
+++ b/common/Will.yml
@@ -1,5 +1,6 @@
 extends: existence
 message: "Avoid using future tense where possible"
+link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-tense
 ignorecase: true
 level: warning
 tokens:

--- a/common/Wordiness.yml
+++ b/common/Wordiness.yml
@@ -1,5 +1,6 @@
 extends: substitution
 message: "Consider using '%s' instead of '%s'"
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-webwriting.html#sec-writing-global
 ignorecase: true
 level: warning
 swap:

--- a/docbook/NoQuotes.yml
+++ b/docbook/NoQuotes.yml
@@ -1,5 +1,6 @@
 extends: existence
 message: "Consider replacing quotation marks with <quote/> in '%s'."
+link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-quotation
 nonword: true
 level: warning
 tokens:

--- a/docbook/NoQuotes.yml
+++ b/docbook/NoQuotes.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: "Consider replacing quotation marks with <quote/> in '%s'."
-link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-quotation
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-quotation
 nonword: true
 level: warning
 tokens:

--- a/docbook/Units.yml
+++ b/docbook/Units.yml
@@ -1,5 +1,6 @@
 extends: existence
 message: "Put a nonbreaking space between the number and the unit in '%s'."
+link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-number
 #nonword: true
 level: error
 tokens:

--- a/docbook/Units.yml
+++ b/docbook/Units.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: "Put a nonbreaking space between the number and the unit in '%s'."
-link: https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-number
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-number
 #nonword: true
 level: error
 tokens:


### PR DESCRIPTION
I've added links to denote sources for rules, in accordance with [SUSE requirements](https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-hyphens) on how to link to SUSE documentation. By which I mean, links were added that refer to:
- html instead of single-html pages
- latest update (current), rather than a specific - possibly outdated - version

The changes will hopefully help to maintain and improve the style guide.

Many rules had a directly identifiable source from the [Language](https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html) section.

Meanwhile, I linked the following rules to ["Writing for a Global Audience"](https://documentation.suse.com/style/current/html/docu_styleguide/sec-webwriting.html#sec-writing-global), since they seemed most in-line with SUSE principle there, "Simplicity, clarity and direct prose are essential", rather than any specific rule in the Language section.
- CorporateSpeak.yml
- Editorializing.yml
- Hedging.yml
- Wordiness.yml

Lastly, I couldn't add the links to these rules since they don't seem to be explicitly stated in the SUSE style guide:
- But.yml
- Colons.yml
- Link.yml
- OptPlural.yml
- Ordinal.yml
- Repetition.yml
- Spacing.yml