### PR TITLE
Update InclusiveLanguage.yml

### DIFF
--- a/common/InclusiveLanguage.yml
+++ b/common/InclusiveLanguage.yml
@@ -7,7 +7,7 @@ tokens:
   - master(?:s)
   - slave(?:s)
   - black hat(?:s)
-  - blacklist(?:s)
+  - black\s?list(?:s)
   - dummy
   - man hour(?:s)
   - manmade
@@ -15,4 +15,4 @@ tokens:
   - middleman
   - native
   - sanity
-  - whitelist
+  - white\s?list(?:s)


### PR DESCRIPTION
I sometimes see `black list` instead of `blacklist`, or `white list` instead of `whitelist`

I added `\s?` to also raise warnings in case the term was divided with a space.