### PR TITLE
Making exceptions case insensitive in Slashes.yml

### DIFF
--- a/common/Slash.yml
+++ b/common/Slash.yml
@@ -1,8 +1,7 @@
 extends: existence
 message: 'Only use slashes with filenames, links and terms such as TCP/IP in "%s"'
-link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-slash
-ignorecase: true
 level: suggestion
+link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-slash
 tokens:
   - '(?<!/)\w+\s?\/\s?\w+'
 exceptions:

--- a/common/Slash.yml
+++ b/common/Slash.yml
@@ -2,6 +2,7 @@ extends: existence
 message: 'Only use slashes with filenames, links and terms such as TCP/IP in "%s"'
 level: suggestion
 link: https://documentation.suse.com/style/current/html/docu_styleguide/sec-language.html#sec-slash
+# Case insensitivity was added with "(?i)" because "ignorecase:true" does not apply to exceptions
 tokens:
   - '(?<!/)\w+\s?\/\s?\w+'
 exceptions:

--- a/common/Slash.yml
+++ b/common/Slash.yml
@@ -8,17 +8,17 @@ tokens:
 exceptions:
   - '\d{2,4}\/\d{2,4}' # To avoid matching dates
   - '\d{1,3}\/\d{1,3}' # to avoid 10.0.1.0/24
-  - 'allow/deny'
-  - 'AMD64/Intel' # To avoid matching "AMD64/Intel 64"
-  - 'client/server'
-  - 'input/output'
-  - 'I/O'
-  - '[kKmMgGtT][bB]/s'
-  - 'N/A'
-  - 'read/write'
-  - 'R/W'
-  - 'SSL/TLS'
-  - 'sync/import'
-  - 'read/write'
-  - 'TCP/IP'
-  - 'Fi/Bluetooth' # To avoid matching "Wi-Fi/Bluetooth card"
+  - '(?i)allow/deny'
+  - '(?i)AMD64/Intel' # To avoid matching "AMD64/Intel 64"
+  - '(?i)client/server'
+  - '(?i)input/output'
+  - '(?i)I/O'
+  - '(?i)[kmgt]b/s'
+  - '(?i)N/A'
+  - '(?i)read/write'
+  - '(?i)R/W'
+  - '(?i)SSL/TLS'
+  - '(?i)sync/import'
+  - '(?i)read/write'
+  - '(?i)TCP/IP'
+  - '(?i)Fi/Bluetooth' # To avoid matching "Wi-Fi/Bluetooth card"

--- a/tests/Slash-good.txt
+++ b/tests/Slash-good.txt
@@ -5,6 +5,7 @@ allow/deny
 AMD64/Intel
 client/server
 input/output
+INPUT/OUTPUT
 I/O
 KB/s
 MB/s
@@ -15,6 +16,8 @@ read/write
 R/W
 SSL/TLS
 sync/import
+SYNC/IMPORT
 read/write
+READ/WRITE
 TCP/IP
 Wi-Fi/Bluetooth


### PR DESCRIPTION
I manually made the exceptions case insensitive since the `ignorecase:true` option didn't do that for the exceptions.

Previously the rule would have raised an error with `READ/WRITE` and would have only accepted `read/write`.

I realize that the changes technically also allow `amd64/intel 64` which doesn't match the TermWeb suggestion of `Amd64/Intel 64`. However, the mistake here is TermWeb related and should be added to that rule, the slash is appropriate.