### PR TITLE
Fix reported long line locations in codeblocks.

### DIFF
--- a/asciidoc/LongScreen.yml
+++ b/asciidoc/LongScreen.yml
@@ -25,15 +25,16 @@ script: |
       offset := block_start
 
       for line in lines {
+          line_length := len(line)
           // Remove trailing backslash if present
           if text.re_match(`\\$`, line) {
               line = line[0:len(line)-1]
           }
-          
-          line_start := offset
-          line_end := offset + len(line)
 
-          if len(line) > 80 {  // Check if the line length is greater than 80
+          line_start := offset
+          line_end := offset + line_length
+
+          if line_length > 80 {  // Check if the line length is greater than 80
               matches = append(matches, { "begin": line_start, "end": line_end })
           }
 

--- a/tests/LongScreen-bad-additional.adoc
+++ b/tests/LongScreen-bad-additional.adoc
@@ -1,0 +1,16 @@
+other text
+
+[source, console]
+----
+openssl req -nodes -batch -newkey rsa:2048 -xxxxkeyout client.key -out client.csr \
+    -addext "subjectAltName = DNS:$FQDN
+openssl req -nodes -batch -newkey rsa:2048 -xxxxxxxxxxxxkeyout client.key -out client.csr \
+    -addext "subjectAltName = DNS:$FQDN
+openssl req -nodes -batch -newkey rsa:2048 -xxkeyout client.key -out client.csr
+openssl req -nodes -batch -newkey rsa:2048 -xxxkeyout client.key -out client.csr \
+    -addext "subjectAltName = DNS:$FQDN
+openssl req -nodes -batch -newkey rsa:2048 -xxxxkeyout client.key -out client.csr
+----
+
+openssl req -nodes -batch -newkey rsa:2048 -xxxxkeyout xxxxxxxxxxxxxxxxxx client.key -out client.csr
+other text


### PR DESCRIPTION
If the line length is measured after a '\\' is tripped then there are errors reported in the location of long lines. Measuring the length once before removing a '\\' avoids this.

Output before:

```
⸘ vale ~/lib/styles-repos/suse-vale-styleguide/tests/LongScreen-bad-additional.adoc 

 /home/jhk/lib/styles-repos/suse-vale-styleguide/tests/LongScreen-bad-additional.adoc
 5:1    suggestion  Break lines longer than 80      asciidoc.LongScreen 
                    characters                                          
 6:40   suggestion  Break lines longer than 80      asciidoc.LongScreen 
                    characters                                          
 9:79   suggestion  Break lines longer than 80      asciidoc.LongScreen 
                    characters                                          
 11:38  suggestion  Break lines longer than 80      asciidoc.LongScreen 
                    characters                                          
 15:1   warning     Check the word 'openssl' for    common.Spelling     
                    typos.                                              
 15:56  warning     Check the word                  common.Spelling     
                    'xxxxxxxxxxxxxxxxxx' for                            
                    typos.                                              

✖ 0 errors, 2 warnings and 4 suggestions in 1 file.
```

Output after the change to LongScreen.yml:

```
⸘ vale ~/lib/styles-repos/suse-vale-styleguide/tests/LongScreen-bad-additional.adoc 

 /home/jhk/lib/styles-repos/suse-vale-styleguide/tests/LongScreen-bad-additional.adoc
 5:1    suggestion  Break lines longer than 80      asciidoc.LongScreen 
                    characters                                          
 7:1    suggestion  Break lines longer than 80      asciidoc.LongScreen 
                    characters                                          
 10:1   suggestion  Break lines longer than 80      asciidoc.LongScreen 
                    characters                                          
 12:1   suggestion  Break lines longer than 80      asciidoc.LongScreen 
                    characters                                          
 15:1   warning     Check the word 'openssl' for    common.Spelling     
                    typos.                                              
 15:56  warning     Check the word                  common.Spelling     
                    'xxxxxxxxxxxxxxxxxx' for                            
                    typos.                                              

✖ 0 errors, 2 warnings and 4 suggestions in 1 file.
```